### PR TITLE
dance-party: celebrate boss kills, finished raids & pet drops

### DIFF
--- a/src/main/java/dekvall/danceparty/DancePartyConfig.java
+++ b/src/main/java/dekvall/danceparty/DancePartyConfig.java
@@ -3,6 +3,7 @@ package dekvall.danceparty;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("danceparty")
 public interface DancePartyConfig extends Config
@@ -10,7 +11,8 @@ public interface DancePartyConfig extends Config
 	@ConfigItem(
 			keyName = "workoutMode",
 			name = "Workout Mode",
-			description = "#1 OSRS fitness inspiration"
+			description = "#1 OSRS fitness inspiration",
+			position = 0
 	)
 	default boolean workoutMode()
 	{
@@ -20,20 +22,68 @@ public interface DancePartyConfig extends Config
 	@ConfigItem(
 			keyName = "disableInPvp",
 			name = "Disable in PvP",
-			description = "Disable dance moves when entering dangerous situations :("
+			description = "Disable dance moves when entering dangerous situations :(",
+			position = 1
 	)
 	default boolean disableInPvp()
 	{
 		return false;
 	}
 
+	@ConfigSection(
+			name = "Only Dance When...",
+			description = "If any of these are enabled, people will only dance if you've accomplished that thing!",
+			closedByDefault = false,
+			position = 2
+	)
+	String conditionalSection = "conditional";
+
 	@ConfigItem(
 			keyName = "partyOnLevelup",
-			name = "Celebrate levelup",
-			description = "Players will only dance when you level up"
+			name = "...You Level Up",
+			description = "Players will dance when you level up",
+			section = conditionalSection,
+			position = 0
 	)
 	default boolean partyOnLevelup()
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "partyOnBossKill",
+			name = "...You Get A Boss Kill",
+			description = "Players will dance when you get a boss kill.",
+			section = conditionalSection,
+			position = 1
+	)
+	default boolean partyOnBossKill()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "partyOnRaidDone",
+			name = "...You Finish A Raid",
+			description = "Players will dance when you get a finish a raid or complete barrows.",
+			section = conditionalSection,
+			position = 2
+	)
+	default boolean partyOnRaidDone()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "partyOnPetDrop",
+			name = "...You Get A Pet Drop",
+			description = "Players will dance when you get a pet drop.",
+			section = conditionalSection,
+			position = 3
+	)
+	default boolean partyOnPetDrop()
+	{
+		return false;
+	}
+
 }


### PR DESCRIPTION
Additional options to dance only during boss kills, completed raids (incl. Barrows) & pet drops.

Merged these options + the "Celebrate Level up" option into a new sub menu "Dance Only When..."