### PR TITLE
Reduce defualt minimum kc to 15

### DIFF
--- a/src/main/java/dev/dkvl/womutils/util/Utils.java
+++ b/src/main/java/dev/dkvl/womutils/util/Utils.java
@@ -31,7 +31,7 @@ public class Utils
             case TZTOK_JAD:
                 return 5;
             default:
-                return 50;
+                return 45;
         }
     }
 

--- a/src/main/java/dev/dkvl/womutils/util/Utils.java
+++ b/src/main/java/dev/dkvl/womutils/util/Utils.java
@@ -31,7 +31,7 @@ public class Utils
             case TZTOK_JAD:
                 return 5;
             default:
-                return 20;
+                return 15;
         }
     }
 

--- a/src/main/java/dev/dkvl/womutils/util/Utils.java
+++ b/src/main/java/dev/dkvl/womutils/util/Utils.java
@@ -31,7 +31,7 @@ public class Utils
             case TZTOK_JAD:
                 return 5;
             default:
-                return 25;
+                return 20;
         }
     }
 

--- a/src/main/java/dev/dkvl/womutils/util/Utils.java
+++ b/src/main/java/dev/dkvl/womutils/util/Utils.java
@@ -31,7 +31,7 @@ public class Utils
             case TZTOK_JAD:
                 return 5;
             default:
-                return 45;
+                return 40;
         }
     }
 

--- a/src/main/java/dev/dkvl/womutils/util/Utils.java
+++ b/src/main/java/dev/dkvl/womutils/util/Utils.java
@@ -31,7 +31,7 @@ public class Utils
             case TZTOK_JAD:
                 return 5;
             default:
-                return 30;
+                return 25;
         }
     }
 

--- a/src/main/java/dev/dkvl/womutils/util/Utils.java
+++ b/src/main/java/dev/dkvl/womutils/util/Utils.java
@@ -31,7 +31,7 @@ public class Utils
             case TZTOK_JAD:
                 return 5;
             default:
-                return 35;
+                return 30;
         }
     }
 

--- a/src/main/java/dev/dkvl/womutils/util/Utils.java
+++ b/src/main/java/dev/dkvl/womutils/util/Utils.java
@@ -31,7 +31,7 @@ public class Utils
             case TZTOK_JAD:
                 return 5;
             default:
-                return 40;
+                return 35;
         }
     }
 


### PR DESCRIPTION
The kc requirements to appear on the boss hiscores has been lowered from 50 to 15.
Jagex is lowering the kc requirements slowly. I will continue to update this pr. 

Latest news post stating the current kc requirement: https://secure.runescape.com/m=news/points-based-combat-achievements?oldschool=1