### PR TITLE
Submit name changes when clan settings interface is opened

### DIFF
--- a/src/main/java/dev/dkvl/womutils/WomUtilsPlugin.java
+++ b/src/main/java/dev/dkvl/womutils/WomUtilsPlugin.java
@@ -265,6 +265,8 @@ public class WomUtilsPlugin extends Plugin
 	private boolean recentlyLoggedIn;
 	private String playerName;
 	private long accountHash;
+	private boolean namechangesSubmitted = false;
+	private SyncButton syncButton;
 
 	private NavigationButton navButton;
 
@@ -489,6 +491,9 @@ public class WomUtilsPlugin extends Plugin
 	{
 		if (queue.isEmpty())
 		{
+			if (syncButton != null) syncButton.setEnabled();
+			namechangesSubmitted = true;
+
 			return;
 		}
 
@@ -498,6 +503,8 @@ public class WomUtilsPlugin extends Plugin
 		try
 		{
 			saveFile();
+			if (syncButton != null) syncButton.setEnabled();
+			namechangesSubmitted = true;
 		}
 		catch (IOException e)
 		{
@@ -731,6 +738,14 @@ public class WomUtilsPlugin extends Plugin
 				break;
 			case CLAN_SETTINGS_INFO_PAGE_WIDGET:
 				clientThread.invoke(() -> createSyncButton(CLAN_SETTINGS_INFO_PAGE_WIDGET_ID));
+				if (namechangesSubmitted)
+				{
+					syncButton.setEnabled();
+				} else
+				{
+					clientThread.invokeLater(this::sendUpdate);
+				}
+
 				break;
 		}
 	}
@@ -879,6 +894,8 @@ public class WomUtilsPlugin extends Plugin
 				lastXp = totalXp;
 				levelupThisSession = false;
 			}
+
+			namechangesSubmitted = false;
 		}
 	}
 
@@ -1174,8 +1191,9 @@ public class WomUtilsPlugin extends Plugin
 	{
 		if (config.syncClanButton() && config.groupId() > 0 && !Strings.isNullOrEmpty(config.verificationCode()))
 		{
-			new SyncButton(client, womClient, chatboxPanelManager, w, groupMembers, ignoredRanks, alwaysIncludedOnSync);
+			syncButton = new SyncButton(client, womClient, chatboxPanelManager, w, groupMembers, ignoredRanks, alwaysIncludedOnSync);
 		}
+
 	}
 
 	@Provides

--- a/src/main/java/dev/dkvl/womutils/ui/SyncButton.java
+++ b/src/main/java/dev/dkvl/womutils/ui/SyncButton.java
@@ -29,6 +29,7 @@ public class SyncButton
     private final Map<String, GroupMembership> groupMembers;
 	private final List<String> ignoredRanks;
 	private final List<String> alwaysIncludedOnSync;
+	private Widget textWidget;
 
 
     public SyncButton(Client client, WomClient womClient, ChatboxPanelManager chatboxPanelManager,
@@ -52,7 +53,7 @@ public class SyncButton
         this.createWidgetWithSprite(SpriteID.EQUIPMENT_BUTTON_EDGE_TOP, 15, 6, 82, 9);
         this.createWidgetWithSprite(SpriteID.EQUIPMENT_BUTTON_EDGE_RIGHT, 97, 15, 9, 5);
         this.createWidgetWithSprite(SpriteID.EQUIPMENT_BUTTON_EDGE_BOTTOM, 15, 20, 82, 9);
-        this.createWidgetWithText();
+        this.textWidget = this.createWidgetWithText();
     }
 
     private void createWidgetWithSprite(int spriteId, int x, int y, int width, int height)
@@ -69,7 +70,7 @@ public class SyncButton
         cornersAndEdges.add(w);
     }
 
-    private void createWidgetWithText()
+    private Widget createWidgetWithText()
     {
         Widget textWidget = this.parent.createChild(-1, WidgetType.TEXT);
         textWidget.setOriginalX(6);
@@ -80,25 +81,18 @@ public class SyncButton
         textWidget.setYPositionMode(WidgetPositionMode.ABSOLUTE_TOP);
         textWidget.setXTextAlignment(WidgetTextAlignment.CENTER);
         textWidget.setYTextAlignment(WidgetTextAlignment.CENTER);
-        textWidget.setText("<col=ffffff>" + "Sync WOM Group" + "</col>");
+        textWidget.setText("<col=9f9f9f>" + "Sync WOM Group" + "</col>");
         textWidget.setFontId(FontID.PLAIN_11);
         textWidget.setTextShadowed(true);
 
         textWidget.setHasListener(true);
         textWidget.setAction(0, "Sync WOM Group");
-        textWidget.setOnOpListener((JavaScriptCallback) e -> {
-            chatboxPanelManager.openTextMenuInput(
-                "Any members not in your clan will be removed" +
-                    "<br>from your WOM group. Proceed?")
-                .option("1. Yes, overwrite WOM group", this::syncMembers)
-				.option("2. No, only add new members", () -> syncMembers(false))
-                .option("3. Cancel", Runnables.doNothing())
-                .build();
-        });
         textWidget.setOnMouseOverListener((JavaScriptCallback) e -> update(true));
         textWidget.setOnMouseLeaveListener((JavaScriptCallback) e -> update(false));
 
         textWidget.revalidate();
+
+		return textWidget;
     }
 
     private void update(boolean hovered)
@@ -155,4 +149,18 @@ public class SyncButton
 
         womClient.syncClanMembers(new ArrayList<>(clanMembers.values()));
     }
+
+	public void setEnabled()
+	{
+		this.textWidget.setText("<col=ffffff>" + "Sync WOM Group" + "</col>");
+		textWidget.setOnOpListener((JavaScriptCallback) e -> {
+			chatboxPanelManager.openTextMenuInput(
+					"Any members not in your clan will be removed" +
+						"<br>from your WOM group. Proceed?")
+				.option("1. Yes, overwrite WOM group", this::syncMembers)
+				.option("2. No, only add new members", () -> syncMembers(false))
+				.option("3. Cancel", Runnables.doNothing())
+				.build();
+		});
+	}
 }


### PR DESCRIPTION
This is a needed change to make [this feature](https://github.com/wise-old-man/wise-old-man/pull/1186) more accurate when merged. It will send the name changes before the sync button is enabled.

The discussion about this can be found a bit before and after this message: https://discord.com/channels/679454777708380161/696219254076342312/1125165902481076275