### PR TITLE
Add "F2P & Level 3" player build

### DIFF
--- a/src/main/java/dev/dkvl/womutils/beans/PlayerBuild.java
+++ b/src/main/java/dev/dkvl/womutils/beans/PlayerBuild.java
@@ -15,6 +15,9 @@ public enum PlayerBuild
     @SerializedName("f2p")
     F2P("F2P"),
 
+    @SerializedName("f2p_lvl3")
+    F2P_LEVEL_3("F2P & Level 3"),
+
     @SerializedName("10hp")
     HP_PURE("10 HP Pure"),
 

--- a/src/main/java/dev/dkvl/womutils/panel/MiscInfoLabel.java
+++ b/src/main/java/dev/dkvl/womutils/panel/MiscInfoLabel.java
@@ -1,5 +1,6 @@
 package dev.dkvl.womutils.panel;
 
+import dev.dkvl.womutils.beans.PlayerBuild;
 import dev.dkvl.womutils.ui.CountryIcon;
 import dev.dkvl.womutils.util.Format;
 import dev.dkvl.womutils.util.Utils;
@@ -47,7 +48,9 @@ public class MiscInfoLabel extends JLabel
                 setText(countryText);
                 break;
             case BUILD:
-                setText(result.getBuild().toString());
+                PlayerBuild build = result.getBuild();
+                String buildText = build == null ? PlayerBuild.MAIN.toString() : build.toString();
+                setText(buildText);
                 setIcon(Utils.getIcon(result.getType()));
                 break;
             case TTM:


### PR DESCRIPTION
This pr also defaults the player build to "Main" if the player build has not yet been implemented in the plugin. Before this it would error and show nothing instead.