### PR TITLE
large logout: fix undesired widget resizing 

### DIFF
--- a/src/main/java/dev/dkvl/largelogout/LargeLogoutPlugin.java
+++ b/src/main/java/dev/dkvl/largelogout/LargeLogoutPlugin.java
@@ -30,7 +30,7 @@ public class LargeLogoutPlugin extends Plugin
 	private static final int ORIG_LOGOUT_BUTTON_HEIGHT = 36;
 	private static final int WIDGET_SPACING = 10;
 
-	private static final int SCRIPT_LOGOUT_LAYOUT_UPDATE = 2176;
+	private static final int SCRIPT_LOGOUT_LAYOUT_UPDATE = 2243;
 
 
 	private static final int WIDGET_LOGOUT_LAYOUT = WidgetInfo.PACK(182, 0);


### PR DESCRIPTION
Replace the current script with [`[proc,logout_layout_update].cs2` (2243)](https://github.com/Joshua-F/cs2-scripts/blob/master/scripts/%5Bproc%2Clogout_layout_update%5D.cs2), this is the underlying script which gets called by both the [init](https://github.com/Joshua-F/cs2-scripts/blob/master/scripts/%5Bclientscript%2Clogout_layout_init%5D.cs2) and [update (current)](https://github.com/Joshua-F/cs2-scripts/blob/master/scripts/%5Bclientscript%2Clogout_layout_update%5D.cs2) scripts.

Fixes #82