### PR TITLE
last recall: Leagues IV support and bug fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'dev.dkvl.lastrecall'
-version = '1.3'
+version = '1.4'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/dev/dkvl/lastrecall/LastRecallPlugin.java
+++ b/src/main/java/dev/dkvl/lastrecall/LastRecallPlugin.java
@@ -1,7 +1,6 @@
 package dev.dkvl.lastrecall;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Provides;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -21,7 +20,6 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
 
@@ -59,7 +57,7 @@ public class LastRecallPlugin extends Plugin
 	private MemoryOverlay memoryOverlay;
 
 	@Override
-	protected void startUp() throws Exception
+	protected void startUp()
 	{
 		log.info("Last Recall started!");
 		WorldPoint recallPoint = config.location();
@@ -68,7 +66,7 @@ public class LastRecallPlugin extends Plugin
 	}
 
 	@Override
-	protected void shutDown() throws Exception
+	protected void shutDown()
 	{
 		worldMapPointManager.removeIf(LastRecallWorldMapPoint.class::isInstance);
 		overlayManager.remove(memoryOverlay);

--- a/src/main/java/dev/dkvl/lastrecall/LastRecallWorldMapPoint.java
+++ b/src/main/java/dev/dkvl/lastrecall/LastRecallWorldMapPoint.java
@@ -11,6 +11,7 @@ class LastRecallWorldMapPoint extends WorldMapPoint
 	private final BufferedImage image;
 	private final BufferedImage arrowIcon;
 	private final Point point;
+	private final String name;
 
 	LastRecallWorldMapPoint(final WorldPoint worldPoint)
 	{
@@ -19,7 +20,9 @@ class LastRecallWorldMapPoint extends WorldMapPoint
 		image = ImageUtil.getResourceStreamFromClass(getClass(), "map-icon.png");
 		arrowIcon = ImageUtil.getResourceStreamFromClass(getClass(), "arrow-icon.png");
 		point = new Point(arrowIcon.getWidth() / 2, arrowIcon.getHeight());
+		name = NamedRegion.fromWorldPoint(worldPoint).getName();
 
+		this.setName(name);
 		this.setSnapToEdge(true);
 		this.setJumpOnClick(true);
 		this.setImage(arrowIcon);

--- a/src/main/java/dev/dkvl/lastrecall/LastRecallWorldMapPoint.java
+++ b/src/main/java/dev/dkvl/lastrecall/LastRecallWorldMapPoint.java
@@ -17,8 +17,8 @@ class LastRecallWorldMapPoint extends WorldMapPoint
 	{
 		super(worldPoint, null);
 
-		image = ImageUtil.getResourceStreamFromClass(getClass(), "map-icon.png");
-		arrowIcon = ImageUtil.getResourceStreamFromClass(getClass(), "arrow-icon.png");
+		image = ImageUtil.loadImageResource(getClass(), "map-icon.png");
+		arrowIcon = ImageUtil.loadImageResource(getClass(), "arrow-icon.png");
 		point = new Point(arrowIcon.getWidth() / 2, arrowIcon.getHeight());
 		name = NamedRegion.fromWorldPoint(worldPoint).getName();
 

--- a/src/main/java/dev/dkvl/lastrecall/RegionShield.java
+++ b/src/main/java/dev/dkvl/lastrecall/RegionShield.java
@@ -17,7 +17,8 @@ enum RegionShield
 	DESERT("Kharidian Desert", 2734),
 	MORYTANIA("Morytania", 2735),
 	TIRANNWN("Tirannwn", 2739),
-	WILDERNESS("Wilderness", 2736);
+	WILDERNESS("Wilderness", 2736),
+	KOUREND("Great Kourend and Kebos Lowlands", 5468);
 
 	private static Map<String, Integer> SHIELDS;
 


### PR DESCRIPTION
This PR intends to fix bugs and add support for a missing Leagues IV region.

Changes include
• The region name is now passed to `WorldMapPoint`: this fixes the previous issue of crashing the client.
• Add support for memory location in Kourend region.
• Minor code cleanup.

Fixes #88 #89 #90 