### PR TITLE
world hider: minor fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'dekvall.worldhider'
-version = '2.0'
+version = '2.0.1'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/dekvall/worldhider/WorldHiderPlugin.java
+++ b/src/main/java/dekvall/worldhider/WorldHiderPlugin.java
@@ -106,6 +106,7 @@ public class WorldHiderPlugin extends Plugin
 			return;
 		}
 
+		getWidgets();
 		clientThread.invokeLater(() ->
 		{
 			updateInterface(worldSwitcher);

--- a/src/main/java/dekvall/worldhider/WorldHiderPlugin.java
+++ b/src/main/java/dekvall/worldhider/WorldHiderPlugin.java
@@ -78,7 +78,7 @@ public class WorldHiderPlugin extends Plugin
 	};
 
 	private final static String MENU_ENTRY_HIDDEN = JagexColors.MENU_TARGET_TAG + "XXX" + ColorUtil.CLOSING_COLOR_TAG;
-	private static final String WORLD_REGEX = "^W\\d{1,3}$";
+	private static final String WORLD_REGEX = "^W\\d{3}$";
 
 	@Inject
 	private Client client;

--- a/src/main/java/dekvall/worldhider/WorldHiderPlugin.java
+++ b/src/main/java/dekvall/worldhider/WorldHiderPlugin.java
@@ -319,8 +319,16 @@ public class WorldHiderPlugin extends Plugin
 		Widget[] entries = widget.getDynamicChildren();
 		final int COLOR = widget.getId() == ComponentID.FRIENDS_CHAT_LIST ? 0xFFFF64 : 0xFFFF00;
 
-		for (Widget entry : entries)
+		for (int i = 0; i < entries.length; i++)
 		{
+			// The world text is the 2nd index per row (player),
+			// and there are 4 widgets per row (player) in the list
+			if (i % 4 != 1)
+			{
+				continue;
+			}
+
+			Widget entry = entries[i];
 			if (entry.getText().matches(WORLD_REGEX) && entry.getType() == WidgetType.TEXT)
 			{
 				if (config.massHide())

--- a/src/main/java/dekvall/worldhider/WorldHiderPlugin.java
+++ b/src/main/java/dekvall/worldhider/WorldHiderPlugin.java
@@ -137,7 +137,7 @@ public class WorldHiderPlugin extends Plugin
 	@Subscribe
 	private void onConfigChanged(ConfigChanged event)
 	{
-		if (!(event.getKey().equals("worldhider") && client.getGameState() == GameState.LOGGED_IN))
+		if (!(event.getGroup().equals("worldhider") && client.getGameState() == GameState.LOGGED_IN))
 		{
 			return;
 		}

--- a/src/main/java/dekvall/worldhider/WorldHiderPlugin.java
+++ b/src/main/java/dekvall/worldhider/WorldHiderPlugin.java
@@ -125,6 +125,7 @@ public class WorldHiderPlugin extends Plugin
 			updateInterface(worldSwitcherPanel);
 			resetWorldSwitcherTitle();
 		});
+		hideWorldMenuEntries(false);
 		hideScrollbar(false);
 		hideToolTip(false);
 	}
@@ -333,8 +334,7 @@ public class WorldHiderPlugin extends Plugin
 
 	private void hideHopperWorlds()
 	{
-		Widget worlds = client.getWidget(ComponentID.WORLD_SWITCHER_WORLD_LIST);
-		hideWorldMenuEntries(worlds, config.hideList());
+		hideWorldMenuEntries(config.hideList());
 
 		if (!config.hideList())
 		{
@@ -365,8 +365,7 @@ public class WorldHiderPlugin extends Plugin
 
 	private void hideConfigurationPanelWorlds()
 	{
-		Widget worlds = client.getWidget(COMPONENT_WORLD_SWITCHER_PANEL, 20);
-		hideWorldMenuEntries(worlds, config.hideConfigurationPanel());
+		hideWorldMenuEntries(config.hideConfigurationPanel());
 
 		if (!config.hideConfigurationPanel())
 		{
@@ -383,8 +382,10 @@ public class WorldHiderPlugin extends Plugin
 		hideFavorites(favorites);
 	}
 
-	private void hideWorldMenuEntries(Widget worldList, boolean hidden)
+	private void hideWorldMenuEntries(boolean hidden)
 	{
+		Widget worldList = client.getWidget(ComponentID.WORLD_SWITCHER_WORLD_LIST);
+
 		if (worldList == null || worldList.getDynamicChildren() == null)
 		{
 			return;
@@ -471,7 +472,7 @@ public class WorldHiderPlugin extends Plugin
 
 	private void updateInterface(Widget component)
 	{
-		if (component == null || component.isHidden())
+		if (component == null)
 		{
 			return;
 		}


### PR DESCRIPTION
This PR aims to fix minor bugs within the plugin:
- Checking the config group instead of the config key on config events
Currently `onConfigChanged` noops because of wrong check.

- Initializing the widgets for the world list interfaces on plugin startup
Currently the widgets are only ever written to on interface load from the script event. Starting the plugin when the interface is already loaded does nothing as the widgets are still null; this fixes the behavior.

- Unhiding the worlds' menu entries on shutdown, to display the associated world number instead of remaining hidden as "_WXXX_".

- Improve the friends chat world hiding to hide widgets by index, this prevents renaming players in the friends chat list to "_WXXX_" if their username matches the regex.  
And limit the regex to exactly 3 digits. This is because it doesn't seem necessary to hide the world number of RS3 worlds, and it may cause grief/confusion for players e.g. if they unknowningly _Hop-to_ RS3 worlds through the world hopper/other plugins.


