### PR TITLE
Adding support for PushCut

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Example notification
 
 ![example-gotify](imgs/gotify-example.png)
 
+## Pushcut
+[Pushcut](https://www.pushcut.io/) is a notification service on iOS, that offers the ability to add _triggers_ to notifications. Meaning, you can trigger an iOS shortcut or open a URL (including deeplinks) by tapping or acknowledging the notification on your device. 
+
+You need to provide the following:
+* **Webhook Secret**: This is automatically created when creating an account. Locate your secret within the Pushcut app by navigating to _account_ -> _webhook_ -> _secret_
+* **Notification Name**: The name for a notification that you create within the app
+
+_**NOTE:**_ Both **Webhook Secret**, and **Notification Name** are CASE SENSITIVE.
+
 # Triggering a push notification
 The easiest way to trigger a push notification is to use the standard notification api: `notifier.notify("notification text")`, the notification text will be forwarded to the configured services.
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'dekvall.pushnotification'
-version = '1.2'
+version = '1.3'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/dekvall/pushnotification/PushNotificationsConfig.java
+++ b/src/main/java/dekvall/pushnotification/PushNotificationsConfig.java
@@ -107,4 +107,27 @@ public interface PushNotificationsConfig extends Config
 	default int gotifyPriority() {
 		return 5;
 	}
+
+	@ConfigSection(
+		name = "Pushcut",
+		description = "Pushcut Settings",
+		position = 4
+	)
+	String pushcutSection = "pushcut";
+
+	@ConfigItem(
+		keyName = "pushcut_notification",
+		name = "Pushcut Notification",
+		description = "Name or reference of the Pushcut notification to trigger",
+		section = pushcutSection
+	)
+	String pushcutNotification();
+
+	@ConfigItem(
+		keyName = "pushcut_secret",
+		name = "Pushcut Secret",
+		description = "Pushcut webhook secret",
+		section = pushcutSection
+	)
+	String pushcutSecret();
 }


### PR DESCRIPTION
Added support for PushCut iOS notifications.

The reason I use PushCut over other push notification services is for its ability to trigger iOS shortcuts and open links upon acknowledging a notification. I use Windows Remote Desktop for heavy AFK activities (gemstone crabs), and I am able to have pushcut open a deeplink (`rdc://`) when tapping my notification to automatically bring the remote client to the foreground on my phone. 